### PR TITLE
Handle null eventData, use the passed json instead

### DIFF
--- a/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/EventUtil.kt
+++ b/android/src/main/kotlin/com/patricktailor/snowplow_flutter_tracker/util/EventUtil.kt
@@ -199,7 +199,7 @@ class EventUtil {
         }
 
         private fun getSelfDescribingJson(json: Map<String, Any>?): SelfDescribingJson {
-            val eventData = json?.get("eventData") as Map<String, Any>?
+            val eventData = json?.get("eventData") as Map<String, Any>? ?: json
             return SelfDescribingJson(eventData?.get("schema") as String, eventData["payload"] as Map<String, Any>)
         }
 


### PR DESCRIPTION
#### Description
This PR fixes the issue of Snowplow in Android. The Android code of the package looks up the context through looking at the evenData property from the context we are passing. The eventData will naturally become null because we are already passing the context.
In iOS code, the eventData isn't being used.

#### How to test this PR?
From the Flutter project, remove the Snowplow package. Then run flutter pub get.
Then add again the package using this code:
```
 snowplow_flutter_tracker:
    git:
      url: https://github.com/Oneflare/snowplow-flutter-tracker.git
      ref: android-screen-view-fix
```
Call trackEvent and trackScreen in any screens in Android.