### PR TITLE
[NT] Updated build.gradle to include namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.patricktailor.snowplow_flutter_tracker'
+
     compileSdkVersion 28
 
     sourceSets {


### PR DESCRIPTION
This is required in newer version of gradle so it's blocking our flutter app from building at the moment